### PR TITLE
Fix JSON payload for Aurora on/off setter

### DIFF
--- a/auri/aurora.py
+++ b/auri/aurora.py
@@ -155,7 +155,7 @@ class Aurora:
     @on.setter
     def on(self, value: bool):
         """Turns the device on/off. True = on, False = off"""
-        data = {"on": value}
+        data = {"on": {"value": value}}
         self.__command("put", "state", data=data)
 
     @property


### PR DESCRIPTION
The API expects value to be an object containing key "value"

Tested with firmware 3.3.6